### PR TITLE
Fixed access to the interface_type property

### DIFF
--- a/pyvisa/resources/resource.py
+++ b/pyvisa/resources/resource.py
@@ -142,7 +142,7 @@ class Resource(object):
         """The interface type of the resource as a number.
         """
         return self.visalib.parse_resource(self._resource_manager.session,
-                                           self.resource_name).interface_type
+                                           self.resource_name)[0].interface_type
 
     def ignore_warning(self, *warnings_constants):
         """Ignoring warnings context manager for the current resource.


### PR DESCRIPTION
When trying to access the 'interface_type' property of my opened resource, I got the following error:
```  File "C:\Python27\lib\site-packages\pyvisa\resources\resource.py", line 145, in interface_type
    self.resource_name).interface_type
AttributeError: 'tuple' object has no attribute 'interface_type' ```

Indexing the first element of that tuple fixed the problem.