### PR TITLE
Add lock exclusive

### DIFF
--- a/pyvisa/ctwrapper/functions.py
+++ b/pyvisa/ctwrapper/functions.py
@@ -794,7 +794,7 @@ def lock(library, session, lock_type, timeout, requested_key=None):
     else:
         access_key = create_string_buffer(256)
     ret = library.viLock(session, lock_type, timeout, requested_key, access_key)
-    return access_key, ret
+    return access_key.value, ret
 
 
 def map_address(library, session, map_space, map_base, map_size,


### PR DESCRIPTION
This improves the locking stuff.
- fixes a timeout calculation
- Changed the value for default and the return value for the lock method.
   These are breaking change, but they should have minimal effect I think (only people that specifically requested a timeout of None will see the behavior change, not specifying it will behave the same way; and using a python value instead of ctypes should alow different backend to work the same way, and allows the use of the return value directly as the requested_key for another lock call).
- added lock_excl and a lock_context (to be used with with statements)
