### PR TITLE
Make container=numpy.array work consistently

### DIFF
--- a/pyvisa/util.py
+++ b/pyvisa/util.py
@@ -192,7 +192,7 @@ def from_ascii_block(ascii_data, converter='f', separator=',', container=list):
     else:
         data = separator(ascii_data)
 
-    return container(converter(raw_value) for raw_value in data)
+    return container([converter(raw_value) for raw_value in data])
 
 
 def to_ascii_block(iterable, converter='f', separator=','):


### PR DESCRIPTION
the line `values = inst.query_ascii_values('CURV?', container=numpy.array)`
from the documentation does not work as expected: it returns an 0-dim numpy
array with a generator object as content.

example code to verify:

```python
from __future__ import print_function, unicode_literals
import numpy
from pyvisa import util

values = util.from_ascii_block("1,2,3,4", container=numpy.array)
print(values)
print(len(values))
```
will throw a `TypeError: len() of unsized object` on 2.7 and 3.4. It works for
binary values as these are parsed into a tuple with struct.unpack so
`numpy.array()` works as expected.

This commit makes query_binary_values and query_ascii_values behave
consistently but will construct a temporary list.