### PR TITLE
Fix for issue 136: UnicodeDecodeError on wrong file for library load

### DIFF
--- a/pyvisa/errors.py
+++ b/pyvisa/errors.py
@@ -11,7 +11,7 @@
     :license: MIT, see LICENSE for more details.
 """
 
-from __future__ import division, unicode_literals, print_function, absolute_import
+from __future__ import division, print_function, absolute_import
 
 from . import util
 from .constants import *

--- a/pyvisa/highlevel.py
+++ b/pyvisa/highlevel.py
@@ -97,7 +97,7 @@ class VisaLibraryBase(object):
         if (cls, library_path) in cls._registry:
             return cls._registry[(cls, library_path)]
 
-        cls._registry[(cls, library_path)] = obj = super(VisaLibraryBase, cls).__new__(cls)
+        obj = super(VisaLibraryBase, cls).__new__(cls)
 
         obj.library_path = library_path
 
@@ -113,6 +113,8 @@ class VisaLibraryBase(object):
         obj.handlers = defaultdict(list)
 
         logger.debug('Created library wrapper for %s', library_path)
+
+        cls._registry[(cls, library_path)] = obj
 
         return obj
 
@@ -1455,7 +1457,7 @@ def open_visa_library(specification):
         return cls(argument)
     except Exception as e:
         logger.debug('Could not open VISA wrapper %s: %s\n%s', cls, str(argument), e)
-        raise e
+        raise
 
 
 class ResourceManager(object):


### PR DESCRIPTION
This is a suggested fix for the error I encountered (see issue 136).

Improves error handling (raise instead of raise e and delayed caching)

And fix the unicode handling problem by removing future import of unicode_literals.
(The error messages from the operating system are not unicode in python 2.7 (windows7), but can contain non-ascii characters. Also the windows library loading requires a string not a unicode, at least in my version.)

There might be other modules where unicode_literals might be removed.