### PR TITLE
Fix reseting of line termination for serial

### DIFF
--- a/pyvisa/resources/messagebased.py
+++ b/pyvisa/resources/messagebased.py
@@ -137,6 +137,9 @@ class MessageBasedResource(Resource):
             self.set_visa_attribute(constants.VI_ATTR_TERMCHAR, ord(last_char))
             self.set_visa_attribute(constants.VI_ATTR_TERMCHAR_EN, constants.VI_TRUE)
         else:
+            # The termchar is also used in VI_ATTR_ASRL_END_IN (for serial termination)
+            # so return it to its default.
+            self.set_visa_attribute(constants.VI_ATTR_TERMCHAR, ord(self.LF))
             self.set_visa_attribute(constants.VI_ATTR_TERMCHAR_EN, constants.VI_FALSE)
 
         self._read_termination = value


### PR DESCRIPTION
When a serial instruments is set to use the VI_ATTR_TERMCHAR for
VI_ATTR_ASRL_END_IN (default) then it uses the value in VI_ATTR_TERMCHAR.

By default read_termination is None, and VI_ATTR_TERMCHAR ends up being the
default value of LF. But when switching around the read_termination to
something (like CR) then coming back to None will leave VI_ATTR_TERMCHAR
in a different state that at the start (with CR instead of LF) and this will
change the behavior of read on serial instruments.

The above change always makes VI_ATTR_TERMCHAR LF when read_termination is set
to None.