### PR TITLE
Improve handlers 2nd part

### DIFF
--- a/pyvisa/highlevel.py
+++ b/pyvisa/highlevel.py
@@ -203,6 +203,23 @@ class VisaLibraryBase(object):
             raise errors.UnknownHandler(event_type, handler, user_handle)
         self.uninstall_handler(session, event_type,  element[2], user_handle)
 
+    def __uninstall_all_handlers_helper(self, session):
+        for element in self.handlers[session]:
+            self.uninstall_handler(session, element[4],  element[2], element[1])
+        del self.handlers[session]
+
+    def uninstall_all_visa_handlers(self, session):
+        """Uninstalls all previously installed handlers for a particular session.
+
+        :param session: Unique logical identifier to a session. If None, operates on all sessions.
+        """
+
+        if session is not None:
+            self.__uninstall_all_handlers_helper(session)
+        else:
+            for session in list(self.handlers):
+                self.__uninstall_all_handlers_helper(session)
+
     def read_memory(self, session, space, offset, width, extended=False):
         """Reads in an 8-bit, 16-bit, 32-bit, or 64-bit value from the specified memory space and offset.
 

--- a/pyvisa/resources/gpib.py
+++ b/pyvisa/resources/gpib.py
@@ -24,12 +24,6 @@ class _GPIBMixin(object):
     """Common attributes and methods of GPIB Instr and Interface.
     """
 
-    def assert_trigger(self):
-        """Sends a software trigger to the device.
-        """
-
-        self.visalib.assert_trigger(self.session, constants.VI_TRIG_PROT_DEFAULT)
-
     def send_command(self, data):
         """Write GPIB command bytes on the bus.
 
@@ -117,12 +111,10 @@ class GPIBInstrument(_GPIBMixin, MessageBasedResource):
         SRQ, only *this* instrument.
 
         :param timeout: the maximum waiting time in milliseconds.
-                        Defaul: 25000 (seconds).
+                        Defaul: 25000 (milliseconds).
                         None means waiting forever if necessary.
         """
-        lib = self.visalib
-
-        lib.enable_event(self.session, constants.VI_EVENT_SERVICE_REQ, constants.VI_QUEUE)
+        self.enable_event(constants.VI_EVENT_SERVICE_REQ, constants.VI_QUEUE)
 
         if timeout and not(0 <= timeout <= 4294967295):
             raise ValueError("timeout value is invalid")
@@ -133,17 +125,15 @@ class GPIBInstrument(_GPIBMixin, MessageBasedResource):
             if timeout is None:
                 adjusted_timeout = constants.VI_TMO_INFINITE
             else:
-                adjusted_timeout = int((starting_time + timeout - time.clock()))
+                adjusted_timeout = int((starting_time + timeout/1e3 - time.clock())*1e3)
                 if adjusted_timeout < 0:
                     adjusted_timeout = 0
 
-            event_type, context, error = lib.wait_on_event(self.session, constants.VI_EVENT_SERVICE_REQ,
-                                                           adjusted_timeout)
-            lib.close(context)
+            self.wait_on_event(constants.VI_EVENT_SERVICE_REQ, adjusted_timeout)
             if self.stb & 0x40:
                 break
 
-        lib.discard_events(self.session, constants.VI_EVENT_SERVICE_REQ, constants.VI_QUEUE)
+        self.discard_events(constants.VI_EVENT_SERVICE_REQ, constants.VI_QUEUE)
 
 
 @Resource.register(constants.InterfaceType.gpib, 'INTFC')

--- a/pyvisa/resources/gpib.py
+++ b/pyvisa/resources/gpib.py
@@ -96,14 +96,6 @@ class GPIBInstrument(_GPIBMixin, MessageBasedResource):
     Do not instantiate directly, use :meth:`pyvisa.highlevel.ResourceManager.open_resource`.
     """
 
-    def before_close(self):
-        self.__switch_events_off()
-        super(GPIBInstrument, self).before_close()
-
-    def __switch_events_off(self):
-        self.visalib.disable_event(self.session, constants.VI_ALL_ENABLED_EVENTS, constants.VI_ALL_MECH)
-        self.visalib.discard_events(self.session, constants.VI_ALL_ENABLED_EVENTS, constants.VI_ALL_MECH)
-
     def wait_for_srq(self, timeout=25000):
         """Wait for a serial request (SRQ) coming from the instrument.
 

--- a/pyvisa/resources/resource.py
+++ b/pyvisa/resources/resource.py
@@ -24,6 +24,20 @@ from .. import highlevel
 from .. import attributes
 
 
+class WaitResponse(object):
+    """Class used in return of wait_on_event. It properly closes the context upon delete.
+    """
+    def __init__(self, event_type, context, ret, visalib, timed_out=False):
+        self.event_type = constants.EventType(event_type)
+        self.context = context
+        self.ret = ret
+        self._visalib = visalib
+        self.timed_out = timed_out
+    def __del__(self):
+        if self.context != None:
+            self._visalib.close(self.context)
+
+
 class Resource(object):
     """Base class for resources.
 
@@ -280,6 +294,25 @@ class Resource(object):
         :param context:  Not currently used, leave as None.
         """
         self.visalib.enable_event(self.session, event_type, mechanism, context)
+
+    def wait_on_event(self, in_event_type, timeout, capture_timeout=False):
+        """Waits for an occurrence of the specified event in this resource.
+
+        :param in_event_type: Logical identifier of the event(s) to wait for.
+        :param timeout: Absolute time period in time units that the resource shall wait for a specified event to
+                        occur before returning the time elapsed error. The time unit is in milliseconds.
+                        None means waiting forever if necessary.
+        :param capture_timeout: When True will not produce a VisaIOError(VI_ERROR_TMO) but
+                                instead return a WaitResponse with timed_out=True
+        :return: A WaitResponse object that contains event_type, context and ret value.
+        """
+        try:
+            event_type, context, ret = self.visalib.wait_on_event(self.session, in_event_type, timeout)
+        except errors.VisaIOError as exc:
+            if capture_timeout and exc.error_code == constants.StatusCode.error_timeout:
+                return WaitResponse(0, None, exc.error_code, self.visalib, timed_out=True)
+            raise
+        return WaitResponse(event_type, context, ret, self.visalib)
 
     def lock(self, timeout='default', requested_key=None):
         """Establish a shared lock to the resource.

--- a/pyvisa/resources/resource.py
+++ b/pyvisa/resources/resource.py
@@ -226,6 +226,7 @@ class Resource(object):
     def __switch_events_off(self):
         self.disable_event(constants.VI_ALL_ENABLED_EVENTS, constants.VI_ALL_MECH)
         self.discard_events(constants.VI_ALL_ENABLED_EVENTS, constants.VI_ALL_MECH)
+        self.visalib.uninstall_all_visa_handlers(self.session)
 
     def get_visa_attribute(self, name):
         """Retrieves the state of an attribute in this resource.

--- a/pyvisa/resources/resource.py
+++ b/pyvisa/resources/resource.py
@@ -207,7 +207,7 @@ class Resource(object):
     def before_close(self):
         """Called just before closing an instrument.
         """
-        pass
+        self.__switch_events_off()
 
     def close(self):
         """Closes the VISA session and marks the handle as invalid.
@@ -222,6 +222,10 @@ class Resource(object):
             self.session = None
         except errors.InvalidSession:
             pass
+
+    def __switch_events_off(self):
+        self.disable_event(constants.VI_ALL_ENABLED_EVENTS, constants.VI_ALL_MECH)
+        self.discard_events(constants.VI_ALL_ENABLED_EVENTS, constants.VI_ALL_MECH)
 
     def get_visa_attribute(self, name):
         """Retrieves the state of an attribute in this resource.


### PR DESCRIPTION
This completes the changes to the handlers (I might add some doc at a later time if I have time)

It adds wait_on_event to all resources.
Cleans up the duplicates and uses the newly available methods in resources for gpib
Moves __switch_events_off to resources
And properly cleanup the visa handlers (and the dictionary cache) upon session close.

This way, closing a session will do a proper cleanup of the events/handlers so most people will not have to use the uninstall/disable interface. In particular I did not try to make uninstall work automatically (install_handler could return and object that cleans up when erased, like I did for wait_on_event, but that would require keeping track of the returned value by the user which not everyone needs to do right now. Since uninstall is not needed often, I kept it simpler.)