### PR TITLE
Moved control_ren to a mixin and added it to USB, GPIB and TCPIP

### DIFF
--- a/pyvisa/resources/gpib.py
+++ b/pyvisa/resources/gpib.py
@@ -17,10 +17,10 @@ import time
 
 from .. import constants
 from .resource import Resource
-from .messagebased import MessageBasedResource
+from .messagebased import MessageBasedResource, ControlRenMixin
 
 
-class _GPIBMixin(object):
+class _GPIBMixin(ControlRenMixin):
     """Common attributes and methods of GPIB Instr and Interface.
     """
 
@@ -47,19 +47,6 @@ class _GPIBMixin(object):
         :rtype: VISAStatus
         """
         return self.visalib.gpib_control_atn(self.session, mode)
-
-    def control_ren(self, mode):
-        """Controls the state of the GPIB Remote Enable (REN) interface line, and optionally the remote/local
-        state of the device.
-
-        Corresponds to viGpibControlREN function of the VISA library.
-
-        :param mode: Specifies the state of the REN line and optionally the device remote/local state.
-                     (Constants.GPIB_REN*)
-        :return: return value of the library call.
-        :rtype: VISAStatus
-        """
-        return self.visalib.gpib_control_ren(self.session, mode)
 
     def pass_control(self, primary_address, secondary_address):
         """Tell the GPIB device at the specified address to become controller in charge (CIC).

--- a/pyvisa/resources/messagebased.py
+++ b/pyvisa/resources/messagebased.py
@@ -55,6 +55,26 @@ class ValuesFormat(object):
         self.header_fmt = header_fmt
 
 
+class ControlRenMixin(object):
+    """Common controlt_ren method of some messaged based resources.
+    """
+    # It should work for GPIB, USB and some TCPIP
+    # For TCPIP I found some (all?) NI's VISA library do not handle control_ren, but
+    # it works for Agilent's VISA library (at least some of them)
+    def control_ren(self, mode):
+        """Controls the state of the GPIB Remote Enable (REN) interface line, and optionally the remote/local
+        state of the device.
+
+        Corresponds to viGpibControlREN function of the VISA library.
+
+        :param mode: Specifies the state of the REN line and optionally the device remote/local state.
+                     (Constants.GPIB_REN*)
+        :return: return value of the library call.
+        :rtype: VISAStatus
+        """
+        return self.visalib.gpib_control_ren(self.session, mode)
+
+
 class MessageBasedResource(Resource):
     """Base class for resources that use message based communication.
     """

--- a/pyvisa/resources/tcpip.py
+++ b/pyvisa/resources/tcpip.py
@@ -16,11 +16,11 @@ from __future__ import division, unicode_literals, print_function, absolute_impo
 from .. import constants
 
 from .resource import Resource
-from .messagebased import MessageBasedResource
+from .messagebased import MessageBasedResource, ControlRenMixin
 
 
 @Resource.register(constants.InterfaceType.tcpip, 'INSTR')
-class TCPIPInstrument(MessageBasedResource):
+class TCPIPInstrument(ControlRenMixin, MessageBasedResource):
     """Communicates with to devices of type TCPIP::host address[::INSTR]
 
     More complex resource names can be specified with the following grammar:

--- a/pyvisa/resources/usb.py
+++ b/pyvisa/resources/usb.py
@@ -14,11 +14,11 @@
 from __future__ import division, unicode_literals, print_function, absolute_import
 
 from .. import constants
-from .messagebased import MessageBasedResource
+from .messagebased import MessageBasedResource, ControlRenMixin
 
 
 @MessageBasedResource.register(constants.InterfaceType.usb, 'INSTR')
-class USBInstrument(MessageBasedResource):
+class USBInstrument(ControlRenMixin, MessageBasedResource):
     """Communicates with devices of type USB::manufacturer ID::model code::serial number
 
     More complex resource names can be specified with the following grammar:


### PR DESCRIPTION
control_ren can be used by more than gpib (can change local/remote state of instrument on usb and tcpip). I created a mixin and used it where I know it will work.
Another option would be to just put control_ren in MessageBasedResource.