### PR TITLE
wait_on_event: create WaitResponse object with correct event_type

### DIFF
--- a/pyvisa/resources/resource.py
+++ b/pyvisa/resources/resource.py
@@ -334,7 +334,7 @@ class Resource(object):
             event_type, context, ret = self.visalib.wait_on_event(self.session, in_event_type, timeout)
         except errors.VisaIOError as exc:
             if capture_timeout and exc.error_code == constants.StatusCode.error_timeout:
-                return WaitResponse(0, None, exc.error_code, self.visalib, timed_out=True)
+                return WaitResponse(in_event_type, None, exc.error_code, self.visalib, timed_out=True)
             raise
         return WaitResponse(event_type, context, ret, self.visalib)
 


### PR DESCRIPTION
If wait_on_event is called with capture_timeout=True and a timeout occurs we try to create a WaitResponse object with 0 as the event type. This will fail, as 0 is not part of the Enum. Create the object with the input event type instead.